### PR TITLE
feat: import dashboards ingress manifest

### DIFF
--- a/ingress/garden.yaml
+++ b/ingress/garden.yaml
@@ -1,0 +1,9 @@
+kind: Deploy
+type: kubernetes
+name: dashboards-ingress
+spec:
+  manifestTemplates:
+    - manifests/dashboards.yaml.tpl
+environments:
+  - local
+  - remote

--- a/ingress/manifests/dashboards.yaml.tpl
+++ b/ingress/manifests/dashboards.yaml.tpl
@@ -1,0 +1,20 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: dashboards-httpproxy
+  namespace: ${environment.namespace}
+spec:
+  virtualhost:
+    fqdn: dashboards.${var.hostname}
+    tls:
+      secretName: dashboards.${var.hostname}-tls
+  routes:
+  - conditions:
+    - prefix: /
+    services:
+    - name: teehr-frontend
+      port: 8080
+    enableWebsockets: true
+    timeoutPolicy:
+      response: 300s
+      idle: 300s


### PR DESCRIPTION
### Summary
Import dashboards ingress manifest and update `teehr-cloud-core` submodule to revision that removes deployment-specific ingress manifests.