### PR TITLE
adds initial warehouse setup and setup_utils

### DIFF
--- a/warehouse_setup/dev/01_setup_fved_minio_warehouse.ipynb
+++ b/warehouse_setup/dev/01_setup_fved_minio_warehouse.ipynb
@@ -1,0 +1,166 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0792a8d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import pandas as pd\n",
+    "\n",
+    "import teehr\n",
+    "from teehr import RemoteReadWriteEvaluation\n",
+    "from teehr.utilities.apply_migrations import evolve_catalog_schema\n",
+    "\n",
+    "from setup_utils import create_minio_spark_session, DEV_LOCATION_ID_LIST"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1810c98d",
+   "metadata": {},
+   "source": [
+    "### Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f535ea8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spark = create_minio_spark_session()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f20b3b5f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "migrations_dir = Path(teehr.__file__).parent / \"migrations\"\n",
+    "\n",
+    "evolve_catalog_schema(\n",
+    "    spark=spark,\n",
+    "    migrations_dir_path=migrations_dir,\n",
+    "    target_catalog_name=\"iceberg\",\n",
+    "    target_namespace_name=\"teehr\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40cb2a0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ev = RemoteReadWriteEvaluation(spark=spark, enable_spark_proxy=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4fbfb4c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# configure download\n",
+    "ev.download.configure(\n",
+    "    api_key='your_key_here'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e646a7b",
+   "metadata": {},
+   "source": [
+    "### Pull domain tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0948e7a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Loading domain tables.\")\n",
+    "\n",
+    "print(\"Loading configurations.\")\n",
+    "ev.download.configurations(\n",
+    "    load=True\n",
+    ")\n",
+    "\n",
+    "print(\"Loading units.\")\n",
+    "ev.download.units(\n",
+    "    load=True\n",
+    ")\n",
+    "\n",
+    "print(\"Loading variables.\")\n",
+    "ev.download.variables(\n",
+    "    load=True\n",
+    ")\n",
+    "\n",
+    "print(\"Loading locations.\")\n",
+    "ev.download.locations(\n",
+    "    ids=DEV_LOCATION_ID_LIST,\n",
+    "    load=True\n",
+    ")\n",
+    "\n",
+    "print(\"Loading location croswalks.\")\n",
+    "ev.download.location_crosswalks(\n",
+    "    primary_location_id=DEV_LOCATION_ID_LIST,\n",
+    "    load=True\n",
+    ")\n",
+    "\n",
+    "print(\"Loading location attributes.\")\n",
+    "ev.download.attributes(\n",
+    "    load=True\n",
+    ")\n",
+    "ev.download.location_attributes(\n",
+    "    location_id=DEV_LOCATION_ID_LIST,\n",
+    "    load=True\n",
+    ")\n",
+    "\n",
+    "print(\"Loading domain variables, locations, crosswalks, and attributes complete!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bfa3efa7",
+   "metadata": {},
+   "source": [
+    "### Kill spark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca94f15b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spark.stop()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "3.10.12",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/warehouse_setup/dev/setup_utils.py
+++ b/warehouse_setup/dev/setup_utils.py
@@ -1,0 +1,23 @@
+from teehr.evaluation.spark_session_utils import create_spark_session
+
+# primary location ids for FVED
+DEV_LOCATION_ID_LIST = [
+    # initial crmms locations w/ usgs record
+    'usgs-09149500',
+    'usgs-09361500',
+    'usgs-09260050'
+]
+
+
+
+def create_minio_spark_session():
+    """Start a Spark session with MinIO credentials and custom configuration."""
+    
+    return create_spark_session(
+    aws_access_key_id="minioadmin",
+    aws_secret_access_key="minioadmin123",
+    update_configs={
+        "spark.hadoop.fs.s3a.aws.credentials.provider":
+        "org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider"
+    }
+)


### PR DESCRIPTION
- Sets up directory for dev warehouse setup. Feel free to let me know if we'd rather organize these files differently than proposed.
  - Adds `01_setup_fved_minio_warehouse.ipynb` to setup the fved minio warehouse and load the domain tables for a subset of locations
  - Adds a `setup_utils.py` (similar to teehr-hub) with a method to create the minio spark session and define a global list of location-ids. 
    - For now -- a test subset of locations is included for 3 CRMMS locations that have a mapped USGS gage. This list will be dynamic and given the small number of sites for FVED (~70), we will likely be able to include all locations for use in testing.
    - Put off loading timeseries data for now as our test POR is still unclear to me given our lack of knowledge around locations, forecast products, etc. Happy to add an additional notebook that mirrors the `teehr-hub` timeseries loading for USGS/NWM forecasts/retrospective timeseries in this PR.