### PR TITLE
refactor: map irsa variables to services

### DIFF
--- a/prefect-workflows/manifests/prefect-job-sa.yaml
+++ b/prefect-workflows/manifests/prefect-job-sa.yaml
@@ -4,4 +4,4 @@ metadata:
   name: prefect-job
   namespace: ${environment.namespace}
   annotations:
-    eks.amazonaws.com/role-arn: ${var.irsa.icebergReadWriteRoleArn}
+    eks.amazonaws.com/role-arn: ${var.irsa.prefectJobRoleArn}

--- a/project.garden.yml
+++ b/project.garden.yml
@@ -17,8 +17,11 @@ variables:
     contextArn: arn:aws:eks:us-east-1:794457362858:cluster/fved-cluster
     ecrRegistry: 794457362858.dkr.ecr.us-east-1.amazonaws.com
   irsa:
-    icebergReadOnlyRoleArn: arn:aws:iam::794457362858:role/fved-iceberg-s3-warehouse-readonly-irsa
-    icebergReadWriteRoleArn: arn:aws:iam::794457362858:role/fved-iceberg-s3-warehouse-irsa
+    icebergRestRoleArn: arn:aws:iam::794457362858:role/fved-iceberg-s3-warehouse-irsa
+    jupyterRoleArn: arn:aws:iam::794457362858:role/fved-iceberg-s3-warehouse-readonly-irsa
+    prefectJobRoleArn: arn:aws:iam::794457362858:role/fved-iceberg-s3-warehouse-irsa
+    sparkRoleArn: arn:aws:iam::794457362858:role/fved-iceberg-s3-warehouse-readonly-irsa
+    trinoRoleArn: arn:aws:iam::794457362858:role/fved-iceberg-s3-warehouse-irsa
 
 environments:
   - name: local

--- a/project.garden.yml
+++ b/project.garden.yml
@@ -28,6 +28,7 @@ environments:
       certificateIssuerName: letsencrypt-prod
       devTeehrVersion: 267f8a75034132aefe84749af10ab1562a6ac169
       stableTeehrVersion: place-holder # Needed for sync to work for some reason.
+      previousTeehrVersion: place-holder
       iceberg:
         inCluster: "true"
         catalogS3PathStyleAccess: "true"

--- a/project.garden.yml
+++ b/project.garden.yml
@@ -16,12 +16,6 @@ variables:
   remoteCluster:
     contextArn: arn:aws:eks:us-east-1:794457362858:cluster/fved-cluster
     ecrRegistry: 794457362858.dkr.ecr.us-east-1.amazonaws.com
-  irsa:
-    icebergRestRoleArn: arn:aws:iam::794457362858:role/fved-iceberg-s3-warehouse-irsa
-    jupyterRoleArn: arn:aws:iam::794457362858:role/fved-iceberg-s3-warehouse-readonly-irsa
-    prefectJobRoleArn: arn:aws:iam::794457362858:role/fved-iceberg-s3-warehouse-irsa
-    sparkRoleArn: arn:aws:iam::794457362858:role/fved-iceberg-s3-warehouse-readonly-irsa
-    trinoRoleArn: arn:aws:iam::794457362858:role/fved-iceberg-s3-warehouse-irsa
 
 environments:
   - name: local
@@ -54,6 +48,12 @@ environments:
       devTeehrVersion: 267f8a75034132aefe84749af10ab1562a6ac169
       stableTeehrVersion: v0.6.5
       previousTeehrVersion: v0.5.3
+      irsa:
+        icebergRestRoleArn: arn:aws:iam::794457362858:role/fved-iceberg-s3-warehouse-irsa
+        jupyterRoleArn: arn:aws:iam::794457362858:role/fved-iceberg-s3-warehouse-readonly-irsa
+        prefectJobRoleArn: arn:aws:iam::794457362858:role/fved-iceberg-s3-warehouse-irsa
+        sparkRoleArn: arn:aws:iam::794457362858:role/fved-iceberg-s3-warehouse-readonly-irsa
+        trinoRoleArn: arn:aws:iam::794457362858:role/fved-iceberg-s3-warehouse-irsa
       iceberg:
         inCluster: "false"
         catalogS3PathStyleAccess: "false"


### PR DESCRIPTION
## Summary
Replace icebergRO and icebergRW IRSA variables with IRSA variables matched to each service.

## Testing
Ran `garden deploy --dry-run -e remote` and verified that no errors occurred due to missing variables.