### PR TITLE
fix: add boto3 to prefect image

### DIFF
--- a/prefect-workflows/Dockerfile.prefect-teehr
+++ b/prefect-workflows/Dockerfile.prefect-teehr
@@ -35,6 +35,9 @@ RUN ARCH=$(uname -m) && \
 # Install Dask distributed for NWM fetching
 RUN pip install dask[distributed]=="2025.7.0" kerchunk=="0.2.7" netcdf4=="1.7.2" numpy=="2.3.1"
 
+# Install boto3 for RiverWare SSM
+RUN pip install boto3
+
 # Install TEEHR with GDAL compatibility for ARM64
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "aarch64" ]; then \


### PR DESCRIPTION
Boto3 required for SSM usage in RiverWare workflow.