### PR TITLE
fix: use botocore for prefect SSM calls

### DIFF
--- a/prefect-workflows/Dockerfile.prefect-teehr
+++ b/prefect-workflows/Dockerfile.prefect-teehr
@@ -35,9 +35,6 @@ RUN ARCH=$(uname -m) && \
 # Install Dask distributed for NWM fetching
 RUN pip install dask[distributed]=="2025.7.0" kerchunk=="0.2.7" netcdf4=="1.7.2" numpy=="2.3.1"
 
-# Install boto3 for RiverWare SSM
-RUN pip install boto3
-
 # Install TEEHR with GDAL compatibility for ARM64
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "aarch64" ]; then \

--- a/prefect-workflows/workflows/riverware/riverware_ssm_run.py
+++ b/prefect-workflows/workflows/riverware/riverware_ssm_run.py
@@ -1,7 +1,7 @@
 import logging
 import time
 
-import boto3
+import botocore.session
 from botocore.exceptions import ClientError
 from prefect import flow, get_run_logger, task
 
@@ -24,7 +24,8 @@ def run_ssm_python_script(
 ) -> dict:
     """Send an SSM RunPowerShellScript command to run a Python script and wait for it to finish."""
     log = get_run_logger()
-    ssm = boto3.client("ssm", region_name=AWS_REGION)
+    session = botocore.session.get_session()
+    ssm = session.create_client("ssm", region_name=AWS_REGION)
 
     command = f'python "{script_path}"'
     log.info(


### PR DESCRIPTION
Separate installation of boto3 is causing version conflicts with the botocore dependency that carries through from teehr. Remove the boto3 installation in the prefect image and use botocore for SSM calls.